### PR TITLE
fix:child show button is't work

### DIFF
--- a/src/views/parent-element.js
+++ b/src/views/parent-element.js
@@ -56,7 +56,7 @@ class parentElement extends LitElement {
             </div>
             <child-element 
                 ?hidden="${this.childHidden}"
-                @hide-child="${this._hideChild()}"
+                @hide-child="${() => this._hideChild()}"
             ></child-element>
         `
     }


### PR DESCRIPTION
resolve #1 

원인 : 잘못된 함수 표기 방법

기존 코드
`@hide-child="${this._hideChild()}`

해결 방법
1. ` @hide-child="${this._hideChild}`
2. ` @hide-child="${() => this._hideChild()}`
3. ` @hide-child="${e => this._hideChild(e)}` //이벤트 객체를 넘겨주고 싶을 때에 사용